### PR TITLE
TYPO3 10 support

### DIFF
--- a/Classes/Service/Version10/AuthenticationService.php
+++ b/Classes/Service/Version10/AuthenticationService.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace HMMH\BeAutoLogin\Service\Version10;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+/**
+ * Class AuthenticationService
+ *
+ */
+class AuthenticationService extends \TYPO3\CMS\Core\Authentication\AuthenticationService
+{
+    const COOKIE_NAME = 'TYPO3_AUTOLOGIN_USER';
+
+    const YEAR_SECONDS = 60 /* seconds */ * 60 /* minutes */ * 24 /* hours */ * 30 /* days */ * 12 /* months */;
+
+    /**
+     * @return bool
+     */
+    protected function hasAllowedRemoteAddress()
+    {
+        $extension = $this->getExtensionConfiguration();
+        $whitelistIpAddresses = GeneralUtility::trimExplode(
+            ',',
+            $extension['whitelistIpAddresses']['value'] ?? $extension['whitelistIpAddresses'],
+            true
+        );
+
+        $remoteAddress = GeneralUtility::getIndpEnv('REMOTE_ADDR');
+
+        foreach ($whitelistIpAddresses as $whitelistIpAddress) {
+            if (GeneralUtility::cmpIP($remoteAddress, $whitelistIpAddress)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array $user
+     *
+     * @return int
+     */
+    public function authUser(array $user): int
+    {
+        return 200;
+    }
+
+    /**
+     * @return array
+     * @throws \TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException
+     * @throws \TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException
+     */
+    function getExtensionConfiguration(): array
+    {
+        /** @var ObjectManager $objectManager */
+        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        /** @var ExtensionConfiguration $configurationUtility */
+        $configurationUtility = $objectManager->get(ExtensionConfiguration::class);
+
+        return $configurationUtility->get('be_auto_login');
+    }
+
+    /**
+     * @return bool
+     */
+    public function getUser()
+    {
+        if (
+            ('cli' !== PHP_SAPI)
+            && Environment::getContext()->isDevelopment()
+            && $this->hasAllowedRemoteAddress()
+        ) {
+            $autoLoginUserName = trim(
+                GeneralUtility::_GET(static::COOKIE_NAME) ?? $_COOKIE[static::COOKIE_NAME] ?? getenv(static::COOKIE_NAME)
+            );
+
+            if ((empty($_COOKIE[static::COOKIE_NAME])) || ($_COOKIE[static::COOKIE_NAME] !== $autoLoginUserName)) {
+                setcookie(static::COOKIE_NAME, $autoLoginUserName, time() + static::YEAR_SECONDS);
+            }
+
+            return $this->fetchUserRecord($autoLoginUserName);
+        } else {
+            return false;
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^8.7.0 || ^9.5.0",
+    "typo3/cms-core": "^8.7.0 || ^9.5.0 || ^10.4",
     "helhum/dotenv-connector": "^2.0"
   },
   "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-9.5.99',
+            'typo3' => '8.7.0-10.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,17 +5,23 @@ if (!defined('TYPO3_MODE')) {
 
 if (\TYPO3\CMS\Core\Utility\GeneralUtility::getApplicationContext()->isDevelopment()) {
     $t3version = \TYPO3\CMS\Core\Utility\VersionNumberUtility::getCurrentTypo3Version();
+    $baseClassName = \HMMH\BeAutoLogin\Service\AuthenticationService::class;
     $className = \HMMH\BeAutoLogin\Service\Version8\AuthenticationService::class;
 
     if (version_compare($t3version, '9.5', '>=')) {
         $className = \HMMH\BeAutoLogin\Service\Version9\AuthenticationService::class;
     }
 
+    if (version_compare($t3version, '10', '>=')) {
+        $baseClassName = \HMMH\BeAutoLogin\Service\Version10\AuthenticationService::class;
+        $className = \HMMH\BeAutoLogin\Service\Version10\AuthenticationService::class;
+    }
+
     // Register new authentication service
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addService(
         $_EXTKEY,
         'auth',
-        \HMMH\BeAutoLogin\Service\AuthenticationService::class,
+        $baseClassName,
         [
             'title' => 'User authentication',
             'description' => 'Auto authentication based .env file.',


### PR DESCRIPTION
We added TYPO3 10 support to `backend-autologin`.

Essentially we copied the TYPO3 9 version of `AuthenticationService` and fixed incompatibilities.

Due to an updated namespace (`\TYPO3\CMS\Sv\AuthenticationService` -> `\TYPO3\CMS\Core\Authentication\AuthenticationService`), we merged methods of the base `AuthenticationService` class into the TYPO3 10 version of `AuthenticationService`.